### PR TITLE
ci: removing rollupTypes from vite to resolve storybook build

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,7 +7,7 @@ import path, { resolve } from "path";
 export default defineConfig({
   plugins: [
     react(),
-    dts({ rollupTypes: true, tsconfigPath: "tsconfig.build.json" }),
+    dts({ rollupTypes: false, tsconfigPath: "tsconfig.build.json" }),
   ],
   build: {
     lib: {


### PR DESCRIPTION
# Description
- Fixed Storybook build breaking because of rollupTypes configuration on vite config